### PR TITLE
Update css classes used as anchors

### DIFF
--- a/src/contents/NewFileSidebar.tsx
+++ b/src/contents/NewFileSidebar.tsx
@@ -25,7 +25,7 @@ const NewFileSidebar = () => {
 }
 
 export const getInlineAnchor: PlasmoGetInlineAnchor = async () => {
-  return document.querySelector(".modal-new-file--list .list-unstyled")
+  return document.querySelector(".modal-new-file-list .list-unstyled")
 }
 
 export default NewFileSidebar

--- a/src/lib/overleaf/openNewFileSection.ts
+++ b/src/lib/overleaf/openNewFileSection.ts
@@ -1,13 +1,13 @@
 export default function openNewFileSection(onClose: () => void) {
-  const body = document.querySelector(".modal-new-file--body")
+  const body = document.querySelector(".modal-new-file.modal-body")
   body.classList.add("hidden")
 
   const newBody = document.createElement("td")
-  newBody.classList.add("modal-new-file--body")
+  newBody.classList.add("modal-new-file", "modal-body")
   newBody.innerHTML = `<div class="better-bibtex-new-file"></div>`
   body.parentElement.appendChild(newBody)
 
-  const listButtons = document.querySelectorAll(".modal-new-file--list button")
+  const listButtons = document.querySelectorAll(".modal-new-file-list button")
   const revert = () => {
     // If we modify the body directly, Overleaf will crash
     // when trying to go back to another page
@@ -26,6 +26,6 @@ export default function openNewFileSection(onClose: () => void) {
   })
 
   document
-    .querySelector(".modal-new-file--list .active")
+    .querySelector(".modal-new-file-list .active")
     .classList.remove("active")
 }


### PR DESCRIPTION
I noticed this extension stopped working with the current overleaf site. Changing some class names makes it at least functional again, there are some issues with styling still. But I consider those not very important.
![image](https://github.com/user-attachments/assets/fa303204-e83e-47c8-bd42-097604aa7aa7)
